### PR TITLE
font-weight numeric value fix

### DIFF
--- a/library/Sheet.js
+++ b/library/Sheet.js
@@ -287,6 +287,9 @@ var Sheet = function () {
                 case 'animation-duration':
                     this.addNumericEndings(styleKeyValue, 's');
                     break;
+                case 'font-weight':
+                    this.addNumericEndings(styleKeyValue, '');
+                    break;
                 default:
                     this.addNumericEndings(styleKeyValue, 'px');
                     break;

--- a/library/Sheet.js
+++ b/library/Sheet.js
@@ -276,6 +276,7 @@ var Sheet = function () {
                 case 'scale':
                 case 'transform':
                 case 'flex':
+                case 'font-weight':
                     break;
                 case 'gradient':
                 case 'background-image':
@@ -286,9 +287,6 @@ var Sheet = function () {
                 case 'animation':
                 case 'animation-duration':
                     this.addNumericEndings(styleKeyValue, 's');
-                    break;
-                case 'font-weight':
-                    this.addNumericEndings(styleKeyValue, '');
                     break;
                 default:
                     this.addNumericEndings(styleKeyValue, 'px');

--- a/source/Sheet.js
+++ b/source/Sheet.js
@@ -259,6 +259,7 @@ export default class Sheet {
             case 'scale':
             case 'transform':
             case 'flex':
+            case 'font-weight':
                 break
             case 'gradient':
             case 'background-image':
@@ -270,9 +271,6 @@ export default class Sheet {
             case 'animation-duration':
                 this.addNumericEndings (styleKeyValue, 's')
                 break
-            case 'font-weight':
-                this.addNumericEndings( styleKeyValue, '' );
-                break;
             default:
                 this.addNumericEndings (styleKeyValue, 'px')
                 break

--- a/source/Sheet.js
+++ b/source/Sheet.js
@@ -270,6 +270,9 @@ export default class Sheet {
             case 'animation-duration':
                 this.addNumericEndings (styleKeyValue, 's')
                 break
+            case 'font-weight':
+                this.addNumericEndings( styleKeyValue, '' );
+                break;
             default:
                 this.addNumericEndings (styleKeyValue, 'px')
                 break

--- a/test/index.html
+++ b/test/index.html
@@ -69,6 +69,7 @@ map text
 
 map title
     font-size 20
+    font-weight 300
 
 map profilePicture
     align center


### PR DESCRIPTION
Doesn't add 'px' after a numeric value by font-weight